### PR TITLE
changePwd & getChatMessageList & fix GetBoardInfo parameter

### DIFF
--- a/src/main/java/com/back/handsUp/baseResponse/BaseResponseStatus.java
+++ b/src/main/java/com/back/handsUp/baseResponse/BaseResponseStatus.java
@@ -17,6 +17,7 @@ public enum BaseResponseStatus {
     INVALID_PASSWORD(false, 4001, "비밀번호가 틀렸습니다."),
     EXIST_USER(false, 4002, "이미 존재하는 유저입니다."),
     INVALID_REQUEST(false, 4003, "입력 양식이 잘못되었습니다."),
+    SAME_PASSWORD(false, 4004, "현재 비밀번호와 변경할 비밀번호가 같습니다."),
 
 
 

--- a/src/main/java/com/back/handsUp/baseResponse/BaseResponseStatus.java
+++ b/src/main/java/com/back/handsUp/baseResponse/BaseResponseStatus.java
@@ -29,6 +29,8 @@ public enum BaseResponseStatus {
     NON_EXIST_SCHOOLIDX(false, 4014, "학교 인덱스가 존재하지 않습니다."),
     NON_EXIST_BOARDUSERIDX(false, 4015, "유저가 작성한 게시물이 아닙니다."),
     NON_EXIST_BOARD_LIST(false, 4016, "게시물이 존재하지 않습니다."),
+    NON_EXIST_CHATROOMIDX(false, 4017, "채팅방이 존재하지 않습니다."),
+
 
 
 

--- a/src/main/java/com/back/handsUp/controller/ChatController.java
+++ b/src/main/java/com/back/handsUp/controller/ChatController.java
@@ -1,0 +1,34 @@
+package com.back.handsUp.controller;
+
+import com.back.handsUp.baseResponse.BaseException;
+import com.back.handsUp.baseResponse.BaseResponse;
+import com.back.handsUp.domain.board.Board;
+import com.back.handsUp.domain.chat.ChatMessage;
+import com.back.handsUp.dto.chat.ChatDto;
+import com.back.handsUp.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/chats")
+@RestController
+public class ChatController {
+    private final ChatService chatService;
+
+    //채팅 메세지 조회
+    @ResponseBody
+    @GetMapping("/{chatRoomIdx}")
+    public BaseResponse<ChatDto.ResChatMessageList> getChatMessages(Principal principal, @PathVariable Long chatRoomIdx){
+        try {
+            ChatDto.ResChatMessageList resChatMessageList = this.chatService.getChatMessages(principal,chatRoomIdx);
+            return new BaseResponse<>(resChatMessageList);
+        }catch (BaseException exception){
+            return new BaseResponse<>((exception.getStatus()));
+        }
+    }
+}

--- a/src/main/java/com/back/handsUp/controller/UserController.java
+++ b/src/main/java/com/back/handsUp/controller/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.security.Principal;
 
 @RequiredArgsConstructor
 @RestController
@@ -61,5 +62,16 @@ public class UserController {
             return new BaseResponse<>((exception.getStatus()));
         }
 
+    }
+
+    @ResponseBody
+    @PatchMapping("/password")
+    public BaseResponse<String> changePwd(Principal principal, @RequestBody UserDto.ReqPwd userPwd){
+        try {
+            this.userService.patchPwd(principal, userPwd);
+            return new BaseResponse<>("비밀번호 변경이 완료되었습니다.");
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
     }
 }

--- a/src/main/java/com/back/handsUp/domain/chat/ChatMessage.java
+++ b/src/main/java/com/back/handsUp/domain/chat/ChatMessage.java
@@ -1,0 +1,41 @@
+package com.back.handsUp.domain.chat;
+
+import com.back.handsUp.baseResponse.BaseEntity;
+import com.back.handsUp.domain.user.User;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import javax.persistence.*;
+
+@Entity
+@Setter
+@Getter
+@Table(name = "chat_message")
+@NoArgsConstructor
+@DynamicInsert
+public class ChatMessage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatMessageIdx;
+
+    @Column(nullable = false)
+    private String chatContents;
+
+    @ManyToOne
+    @JoinColumn(name = "chatRoomIdx")
+    private ChatRoom chatRoomIdx;
+
+    @OneToOne
+    @JoinColumn(name = "userIdx")
+    private User userIdx;
+
+    @Column(columnDefinition = "varchar(10) default 'ACTIVE'")
+    private String status;
+
+    @Builder
+    public ChatMessage(String chatContents, ChatRoom chatRoomIdx, User userIdx) {
+        this.chatContents = chatContents;
+        this.chatRoomIdx = chatRoomIdx;
+        this.userIdx = userIdx;
+    }
+}

--- a/src/main/java/com/back/handsUp/domain/chat/ChatRoom.java
+++ b/src/main/java/com/back/handsUp/domain/chat/ChatRoom.java
@@ -1,0 +1,42 @@
+package com.back.handsUp.domain.chat;
+
+import com.back.handsUp.baseResponse.BaseEntity;
+import com.back.handsUp.domain.board.Board;
+import com.back.handsUp.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicInsert;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Setter
+@Getter
+@Table(name = "chat_room")
+@NoArgsConstructor
+@DynamicInsert
+public class ChatRoom extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatRoomIdx;
+
+    @OneToOne
+    @JoinColumn(name = "boardIdx")
+    private Board boardIdx;
+
+    @OneToOne
+    @JoinColumn(name = "userIdx")
+    private User userIdx;
+
+    @Column(columnDefinition = "varchar(10) default 'ACTIVE'")
+    private String status;
+
+    @Builder
+    public ChatRoom(Board boardIdx, User userIdx) {
+        this.boardIdx = boardIdx;
+        this.userIdx = userIdx;
+    }
+}

--- a/src/main/java/com/back/handsUp/domain/user/User.java
+++ b/src/main/java/com/back/handsUp/domain/user/User.java
@@ -69,6 +69,10 @@ public class User extends BaseEntity {
         this.status = newStatus;
     }
 
+    public void changePWd(String newPwd) {
+        this.password = newPwd;
+    }
+
     public String getRoleName(){
         return this.role.name();
     }

--- a/src/main/java/com/back/handsUp/dto/board/BoardDto.java
+++ b/src/main/java/com/back/handsUp/dto/board/BoardDto.java
@@ -16,7 +16,7 @@ public class BoardDto {
         private String indicateLocation;
         private String location;
         private String content;
-        private List<String> tagList;
+        private String tag;
         private int messageDuration;
     }
 }

--- a/src/main/java/com/back/handsUp/dto/chat/ChatDto.java
+++ b/src/main/java/com/back/handsUp/dto/chat/ChatDto.java
@@ -1,0 +1,36 @@
+package com.back.handsUp.dto.chat;
+
+import com.back.handsUp.domain.board.Board;
+import com.back.handsUp.domain.user.Character;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor
+public class ChatDto {
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class ResChatMessageList {
+        private Board board;
+        private Character character;
+        private String nickname;
+        private List<BriefChatMessage> chatMessageList;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class BriefChatMessage {
+        private Long chatMessageIdx;
+        private Long userIdx; //메세지를 보낸 유저 (A->B이면 A)
+        private String chatContents;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/back/handsUp/dto/user/UserDto.java
+++ b/src/main/java/com/back/handsUp/dto/user/UserDto.java
@@ -39,4 +39,12 @@ public class UserDto {
         @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
         private String password;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ReqPwd {
+        private String currentPwd;
+        private String newPwd;
+    }
 }

--- a/src/main/java/com/back/handsUp/repository/board/BoardUserRepository.java
+++ b/src/main/java/com/back/handsUp/repository/board/BoardUserRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 @Repository
 public interface BoardUserRepository extends JpaRepository<BoardUser, Long> {
-    Optional<BoardUser> findBoardUserByBoardIdx(Long boardIdx);
+    Optional<BoardUser> findBoardUserByBoardIdx(Board boardIdx);
 
     @Query("select b.boardIdx from BoardUser b where b.userIdx = ?1 and b.status = ?2")
     List<Board> findBoardIdxByUserIdxAndStatus(User userIdx, String status);

--- a/src/main/java/com/back/handsUp/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/back/handsUp/repository/chat/ChatMessageRepository.java
@@ -1,0 +1,14 @@
+package com.back.handsUp.repository.chat;
+
+import com.back.handsUp.domain.chat.ChatMessage;
+import com.back.handsUp.domain.chat.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    List<ChatMessage> findByChatRoomIdxOrderByChatMessageIdxDesc(ChatRoom chatRoomIdx);
+    //Todo: 채팅 조회 동적 페이지네이션 적용
+//    List<ChatMessage> findByChatMessageIdxLessThanAndChatRoomIdxAndUserIdxInOrderByChatMessageIdxDesc(Long lastChatMessageIdx,Long chatRoomIdx);
+
+}

--- a/src/main/java/com/back/handsUp/repository/chat/ChatRoomRepository.java
+++ b/src/main/java/com/back/handsUp/repository/chat/ChatRoomRepository.java
@@ -1,0 +1,10 @@
+package com.back.handsUp.repository.chat;
+
+import com.back.handsUp.domain.chat.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    Optional<ChatRoom> findByChatRoomIdx(Long chatRoomIdx);
+}

--- a/src/main/java/com/back/handsUp/service/BoardService.java
+++ b/src/main/java/com/back/handsUp/service/BoardService.java
@@ -128,7 +128,6 @@ public class BoardService {
                 .collect(Collectors.toList());
     }
 
-    //Todo: 로그인 구현 후 userIdx->principal
     public void addBoard(Principal principal, BoardDto.GetBoardInfo boardInfo) throws BaseException {
 
         if(boardInfo.getIndicateLocation().equals("true") && boardInfo.getLocation() == null){
@@ -170,7 +169,6 @@ public class BoardService {
 
     }
 
-    //boardIdx->principal
     public void patchBoard(Principal principal, Long boardIdx, BoardDto.GetBoardInfo boardInfo) throws BaseException{
         if(boardInfo.getIndicateLocation().equals("true") && boardInfo.getLocation() == null){
             throw new BaseException(BaseResponseStatus.LOCATION_ERROR);
@@ -217,14 +215,12 @@ public class BoardService {
     }
 
     private void setTags(BoardDto.GetBoardInfo boardInfo, Board boardEntity) {
-        List<String> tagNameList = boardInfo.getTagList();
-        for(String tmp: tagNameList){
-            Optional<Tag> tagEntity = this.tagRepository.findByName(tmp);
+            Optional<Tag> tagEntity = this.tagRepository.findByName(boardInfo.getTag());
             Tag targetTag;
 
             if(tagEntity.isEmpty()){
                 targetTag = Tag.builder()
-                        .name(tmp)
+                        .name(boardInfo.getTag())
                         .build();
                 this.tagRepository.save(targetTag);
             } else {
@@ -242,6 +238,5 @@ public class BoardService {
                 BoardTag boardTagEntity = optional.get();
                 boardTagEntity.changeStatus("ACTIVE");
             }
-        }
     }
 }

--- a/src/main/java/com/back/handsUp/service/ChatService.java
+++ b/src/main/java/com/back/handsUp/service/ChatService.java
@@ -1,0 +1,75 @@
+package com.back.handsUp.service;
+
+import com.back.handsUp.baseResponse.BaseException;
+import com.back.handsUp.baseResponse.BaseResponseStatus;
+import com.back.handsUp.domain.board.BoardUser;
+import com.back.handsUp.domain.chat.ChatMessage;
+import com.back.handsUp.domain.chat.ChatRoom;
+import com.back.handsUp.domain.user.User;
+import com.back.handsUp.dto.chat.ChatDto;
+import com.back.handsUp.repository.board.BoardUserRepository;
+import com.back.handsUp.repository.chat.ChatMessageRepository;
+import com.back.handsUp.repository.chat.ChatRoomRepository;
+import com.back.handsUp.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class ChatService {
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+    private final BoardUserRepository boardUserRepository;
+
+    //채팅 메세지 조회
+    public ChatDto.ResChatMessageList getChatMessages(Principal principal, Long chatRoomIdx) throws BaseException {
+        Optional<User> optional = this.userRepository.findByEmail(principal.getName());
+        if(optional.isEmpty()){
+            throw new BaseException(BaseResponseStatus.NON_EXIST_EMAIL);
+        }
+
+        Optional<ChatRoom> optional1 = this.chatRoomRepository.findByChatRoomIdx(chatRoomIdx);
+        if(optional1.isEmpty()){
+            throw new BaseException(BaseResponseStatus.NON_EXIST_CHATROOMIDX);
+        }
+        ChatRoom chatRoom = optional1.get();
+        List<ChatMessage> chatMessageList = this.chatMessageRepository.findByChatRoomIdxOrderByChatMessageIdxDesc(chatRoom);
+        List<ChatDto.BriefChatMessage> briefChatMessageList = new ArrayList<>();
+        for(ChatMessage chat: chatMessageList){
+            ChatDto.BriefChatMessage briefChatMessage = ChatDto.BriefChatMessage.builder()
+                    .chatMessageIdx(chat.getChatMessageIdx())
+                    .userIdx(chat.getUserIdx().getUserIdx())
+                    .chatContents(chat.getChatContents())
+                    .createdAt(chat.getCreatedAt())
+                    .build();
+
+            briefChatMessageList.add(briefChatMessage);
+        }
+
+        Optional<BoardUser> optional2 = this.boardUserRepository.findBoardUserByBoardIdx(chatRoom.getBoardIdx());
+        if(optional2.isEmpty()){
+            throw new BaseException(BaseResponseStatus.NON_EXIST_BOARDUSERIDX);
+        }
+        BoardUser boardUser = optional2.get();
+
+
+        ChatDto.ResChatMessageList resChatMessageList =ChatDto.ResChatMessageList.builder()
+                .board(chatRoom.getBoardIdx())
+                .character(boardUser.getUserIdx().getCharacterIdx())
+                .nickname(boardUser.getUserIdx().getNickname())
+                .chatMessageList(briefChatMessageList)
+                .build();
+
+        return resChatMessageList;
+    }
+}


### PR DESCRIPTION
### 📝 작업 내용
- 비밀번호 변경 API 
- 채팅 조회 API
- `GetBoardInfo`의 파라미터 `tag`로 변경 (tag 다중 선택 &rarr; 단일 선택 변경으로 인한 이슈)
### 📢 특이 사항
- 이후에 채팅 조회 API  &rarr; 동적 페이지네이션 적용하는 것으로 변경할 것
