### PR TITLE
certify school email & ChatRoom API & Jasypt & JWT exception Response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ###
 src/main/resources/firebase/handsup-c4213-firebase-adminsdk-cecbd-589582696c.json
+
+### Naver Mail Password (jasypt-encryptor-password) ###
+src/main/resources/jasypt/jasypt-encryptor-password.txt

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3'
 
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperty 'jasypt.encryptor.password', findProperty("jasypt.encryptor.password")
 }

--- a/src/main/java/com/back/handsUp/baseResponse/BaseResponseStatus.java
+++ b/src/main/java/com/back/handsUp/baseResponse/BaseResponseStatus.java
@@ -39,6 +39,14 @@ public enum BaseResponseStatus {
 
     NON_EXIST_CHARACTER_VALUE(false,4031,"캐릭터 생성에 필요한 값이 모두 입력되지 않았습니다."),
 
+    REFRESH_TOKEN_ERROR(false,4040,"Refresh Token이 유효하지 않습니다."),
+    LOGOUT_USER(false,4041,"로그아웃된 사용자입니다."),
+    NOT_MATCH_TOKEN(false,4042,"토큰의 유저 정보가 일치하지 않습니다."),
+    MALFORMED_JWT(false,4043,"잘못된 JWT 서명입니다."),
+    EXPIRED_JWT(false,4044,"만료된 JWT 토큰입니다."),
+    UNSUPPORTED_JWT(false,4045,"지원되지 않는 JWT 토큰입니다."),
+    ILLEGAL_JWT(false,4046,"JWT 토큰이 잘못되었습니다."),
+    JWT_ERROR(false,4047,"JWT 토큰에 오류가 발생했습니다."),
 
 
     /**

--- a/src/main/java/com/back/handsUp/baseResponse/BaseResponseStatus.java
+++ b/src/main/java/com/back/handsUp/baseResponse/BaseResponseStatus.java
@@ -53,8 +53,8 @@ public enum BaseResponseStatus {
      * 5000번대 서버 에러
      */
     DATABASE_INSERT_ERROR(false, 5000, "데이터베이스 저장 오류가 발생했습니다."),
-    PASSWORD_ENCRYPTION_ERROR(false, 5001, "비밀번호 암호화 오류가 발생했습니다.");
-
+    PASSWORD_ENCRYPTION_ERROR(false, 5001, "비밀번호 암호화 오류가 발생했습니다."),
+    EMAIL_SEND_ERROR(false, 5002, "이메일 인증번호 발송에 오류가 발생했습니다.");
 
     private final boolean isSuccess;
     private final int statusCode;

--- a/src/main/java/com/back/handsUp/config/JasyptConfig.java
+++ b/src/main/java/com/back/handsUp/config/JasyptConfig.java
@@ -1,0 +1,45 @@
+package com.back.handsUp.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Configuration
+public class JasyptConfig {
+
+    @Bean("jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor(){
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(getJasyptEncryptorPassword());
+        config.setPoolSize("1");
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setStringOutputType("base64");
+        config.setKeyObtentionIterations("1000");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+
+    private String getJasyptEncryptorPassword() {
+        try {
+            ClassPathResource resource = new ClassPathResource("jasypt/jasypt-encryptor-password.txt");
+            String password = Files.readAllLines(Paths.get(resource.getURI())).stream()
+                    .collect(Collectors.joining(""));
+//            log.info("jasypt password: "+password);
+            return password;
+        } catch (IOException e) {
+            throw new RuntimeException("Not found Jasypt password file.");
+        }
+    }
+}

--- a/src/main/java/com/back/handsUp/config/MailConfig.java
+++ b/src/main/java/com/back/handsUp/config/MailConfig.java
@@ -1,0 +1,47 @@
+package com.back.handsUp.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@PropertySource("classpath:application.properties")
+public class MailConfig {
+    @Value("${spring.mail.username}")
+    private String id;
+    @Value("${spring.mail.password}")
+    private String password;
+    @Value("${spring.mail.host}")
+    private String host;
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setHost(host);
+        javaMailSender.setUsername(id);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(port);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+        javaMailSender.setDefaultEncoding("UTF-8");
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.transport.protocol", "smtp");
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+        properties.setProperty("mail.debug", "true");
+        properties.setProperty("mail.smtp.ssl.trust","smtp.naver.com");
+        properties.setProperty("mail.smtp.ssl.enable","true");
+        return properties;
+    }
+}

--- a/src/main/java/com/back/handsUp/config/SecurityConfig.java
+++ b/src/main/java/com/back/handsUp/config/SecurityConfig.java
@@ -44,11 +44,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
 
-                // 로그인, 회원가입, 재발급 API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
+                // 로그인, 회원가입, 액세스토큰 재발급, 학교인증, 캐릭터생성 API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
                 .authorizeRequests()
                 .antMatchers("/users/login").permitAll()
                 .antMatchers("/users/signup").permitAll()
                 .antMatchers("/users/reissue").permitAll()
+                .antMatchers("/users/certify").permitAll()
+                .antMatchers("/users/create/character").permitAll()
+
                 .anyRequest().authenticated()  // 나머지 API 는 전부 인증 필요
 
 

--- a/src/main/java/com/back/handsUp/config/SecurityConfig.java
+++ b/src/main/java/com/back/handsUp/config/SecurityConfig.java
@@ -44,10 +44,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
 
-                // 로그인, 회원가입 API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
+                // 로그인, 회원가입, 재발급 API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
                 .authorizeRequests()
                 .antMatchers("/users/login").permitAll()
                 .antMatchers("/users/signup").permitAll()
+                .antMatchers("/users/reissue").permitAll()
                 .anyRequest().authenticated()  // 나머지 API 는 전부 인증 필요
 
 

--- a/src/main/java/com/back/handsUp/controller/ChatController.java
+++ b/src/main/java/com/back/handsUp/controller/ChatController.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,10 +22,10 @@ public class ChatController {
     //채팅 메세지 조회
     @ResponseBody
     @GetMapping("/{chatRoomIdx}")
-    public BaseResponse<ChatDto.ResChatMessageList> getChatMessages(Principal principal, @PathVariable Long chatRoomIdx){
+    public BaseResponse<ChatDto.ResChat> getChatMessages(Principal principal, @PathVariable Long chatRoomIdx){
         try {
-            ChatDto.ResChatMessageList resChatMessageList = this.chatService.getChatMessages(principal,chatRoomIdx);
-            return new BaseResponse<>(resChatMessageList);
+            ChatDto.ResChat resChat = this.chatService.getChatInfo(principal,chatRoomIdx);
+            return new BaseResponse<>(resChat);
         }catch (BaseException exception){
             return new BaseResponse<>((exception.getStatus()));
         }

--- a/src/main/java/com/back/handsUp/controller/UserController.java
+++ b/src/main/java/com/back/handsUp/controller/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.security.Principal;
 
@@ -101,6 +102,18 @@ public class UserController {
         }catch (BaseException exception) {
             return new BaseResponse<>((exception.getStatus()));
 
+        }
+    }
+
+    //액세스 토큰 재발급
+    @ResponseBody
+    @PostMapping("/reissue")
+    public BaseResponse<TokenDto> reissue(@RequestBody TokenDto token, HttpServletRequest request) {
+        try {
+            TokenDto newToken = this.userService.reissue(token, request);
+            return new BaseResponse<>(newToken);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
         }
     }
 }

--- a/src/main/java/com/back/handsUp/controller/UserController.java
+++ b/src/main/java/com/back/handsUp/controller/UserController.java
@@ -7,10 +7,10 @@ import com.back.handsUp.domain.user.Character;
 import com.back.handsUp.dto.jwt.TokenDto;
 import com.back.handsUp.dto.user.CharacterDto;
 import com.back.handsUp.dto.user.UserDto;
+import com.back.handsUp.service.MailService;
 import com.back.handsUp.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -22,6 +22,7 @@ import java.security.Principal;
 @RequestMapping(value = "/users")
 public class UserController {
     private final UserService userService;
+    private final MailService mailService;
 
     @ResponseBody
     @PostMapping("/signup")
@@ -112,6 +113,18 @@ public class UserController {
         try {
             TokenDto newToken = this.userService.reissue(token, request);
             return new BaseResponse<>(newToken);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    //학교 인증
+    @ResponseBody
+    @PostMapping("/certify")
+    public BaseResponse<String> certify(@RequestBody UserDto.ResEmail resEmail){
+        try {
+            String code = this.mailService.sendMail(resEmail.getEmail());
+            return new BaseResponse<>(code);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/com/back/handsUp/domain/user/User.java
+++ b/src/main/java/com/back/handsUp/domain/user/User.java
@@ -35,7 +35,7 @@ public class User extends BaseEntity {
     @Column(nullable = false, length = 15)
     private String nickname;
 
-    @Column(columnDefinition="date default (current_date)")
+    @Column(columnDefinition="date default (current_date)", updatable = false)
     private Date nicknameUpdatedAt;
 
     @OneToOne

--- a/src/main/java/com/back/handsUp/dto/chat/ChatDto.java
+++ b/src/main/java/com/back/handsUp/dto/chat/ChatDto.java
@@ -16,21 +16,10 @@ public class ChatDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class ResChatMessageList {
+    public static class ResChat {
         private Board board;
         private Character character;
         private String nickname;
-        private List<BriefChatMessage> chatMessageList;
     }
 
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    public static class BriefChatMessage {
-        private Long chatMessageIdx;
-        private Boolean isMe; //메세지를 보낸 유저가 '나'이면 TRUE
-        private String chatContents;
-        private LocalDateTime createdAt;
-    }
 }

--- a/src/main/java/com/back/handsUp/dto/chat/ChatDto.java
+++ b/src/main/java/com/back/handsUp/dto/chat/ChatDto.java
@@ -29,7 +29,7 @@ public class ChatDto {
     @Builder
     public static class BriefChatMessage {
         private Long chatMessageIdx;
-        private Long userIdx; //메세지를 보낸 유저 (A->B이면 A)
+        private Boolean isMe; //메세지를 보낸 유저가 '나'이면 TRUE
         private String chatContents;
         private LocalDateTime createdAt;
     }

--- a/src/main/java/com/back/handsUp/dto/user/UserDto.java
+++ b/src/main/java/com/back/handsUp/dto/user/UserDto.java
@@ -60,4 +60,12 @@ public class UserDto {
         private Long userIdx;
     }
 
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Getter
+    public static class ResEmail {
+        private String email;
+    }
+
 }

--- a/src/main/java/com/back/handsUp/dto/user/UserDto.java
+++ b/src/main/java/com/back/handsUp/dto/user/UserDto.java
@@ -28,7 +28,7 @@ public class UserDto {
         private String nickname;
 
         private Long characterIdx;
-        private Long schoolIdx;
+        private String schoolName;
     }
 
     @Getter

--- a/src/main/java/com/back/handsUp/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/com/back/handsUp/repository/chat/ChatMessageRepository.java
@@ -7,8 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    List<ChatMessage> findByChatRoomIdxOrderByChatMessageIdxDesc(ChatRoom chatRoomIdx);
-    //Todo: 채팅 조회 동적 페이지네이션 적용
-//    List<ChatMessage> findByChatMessageIdxLessThanAndChatRoomIdxAndUserIdxInOrderByChatMessageIdxDesc(Long lastChatMessageIdx,Long chatRoomIdx);
-
 }

--- a/src/main/java/com/back/handsUp/repository/user/SchoolRepository.java
+++ b/src/main/java/com/back/handsUp/repository/user/SchoolRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface SchoolRepository extends JpaRepository<School, Long> {
     Optional<School> findBySchoolIdx(Long schoolIdx);
+    Optional<School> findByName(String name);
 }

--- a/src/main/java/com/back/handsUp/service/ChatService.java
+++ b/src/main/java/com/back/handsUp/service/ChatService.java
@@ -3,13 +3,11 @@ package com.back.handsUp.service;
 import com.back.handsUp.baseResponse.BaseException;
 import com.back.handsUp.baseResponse.BaseResponseStatus;
 import com.back.handsUp.domain.board.BoardUser;
-import com.back.handsUp.domain.chat.ChatMessage;
 import com.back.handsUp.domain.chat.ChatRoom;
 import com.back.handsUp.domain.user.Character;
 import com.back.handsUp.domain.user.User;
 import com.back.handsUp.dto.chat.ChatDto;
 import com.back.handsUp.repository.board.BoardUserRepository;
-import com.back.handsUp.repository.chat.ChatMessageRepository;
 import com.back.handsUp.repository.chat.ChatRoomRepository;
 import com.back.handsUp.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +16,6 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.security.Principal;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -27,7 +23,6 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Transactional
 public class ChatService {
-    private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
     private final BoardUserRepository boardUserRepository;
@@ -54,9 +49,9 @@ public class ChatService {
 
         Character character;
         if(loginUser.equals(boardUser.getUserIdx())){
-            character = chatRoom.getUserIdx().getCharacterIdx();
+            character = chatRoom.getUserIdx().getCharacter();
         } else {
-            character = boardUser.getUserIdx().getCharacterIdx();
+            character = boardUser.getUserIdx().getCharacter();
         }
 
         ChatDto.ResChat resChat = ChatDto.ResChat.builder()

--- a/src/main/java/com/back/handsUp/service/ChatService.java
+++ b/src/main/java/com/back/handsUp/service/ChatService.java
@@ -46,9 +46,15 @@ public class ChatService {
         List<ChatMessage> chatMessageList = this.chatMessageRepository.findByChatRoomIdxOrderByChatMessageIdxDesc(chatRoom);
         List<ChatDto.BriefChatMessage> briefChatMessageList = new ArrayList<>();
         for(ChatMessage chat: chatMessageList){
+            Boolean isMe;
+            if(chat.getUserIdx().equals(optional.get())){
+                isMe=Boolean.TRUE;
+            } else{
+                isMe=Boolean.FALSE;
+            }
             ChatDto.BriefChatMessage briefChatMessage = ChatDto.BriefChatMessage.builder()
                     .chatMessageIdx(chat.getChatMessageIdx())
-                    .userIdx(chat.getUserIdx().getUserIdx())
+                    .isMe(isMe)
                     .chatContents(chat.getChatContents())
                     .createdAt(chat.getCreatedAt())
                     .build();

--- a/src/main/java/com/back/handsUp/service/MailService.java
+++ b/src/main/java/com/back/handsUp/service/MailService.java
@@ -1,0 +1,70 @@
+package com.back.handsUp.service;
+
+import com.back.handsUp.baseResponse.BaseException;
+import com.back.handsUp.baseResponse.BaseResponse;
+import com.back.handsUp.baseResponse.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import javax.transaction.Transactional;
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+
+@PropertySource("classpath:application.properties")
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class MailService {
+    private final JavaMailSender javaMailSender;
+    @Value("${spring.mail.username}")
+    private String email;
+
+    private MimeMessage createMessage(String code, String emailTo) throws MessagingException, UnsupportedEncodingException {
+        MimeMessage  message = javaMailSender.createMimeMessage();
+
+        message.addRecipients(MimeMessage.RecipientType.TO, emailTo); //보내는 사람
+        message.setSubject("핸즈업 이메일 인증번호:"); //메일 제목
+        // 메일 내용 메일의 subtype을 html로 지정하여 html문법 사용 가능
+        String msg="";
+        msg += "<h1 style=\"font-size: 30px; padding-right: 30px; padding-left: 30px;\">이메일 주소 확인</h1>";
+        msg += "<p style=\"font-size: 17px; padding-right: 30px; padding-left: 30px;\">아래 인증번호를 회원가입 화면에서 입력해주세요.</p>";
+        msg += "<div style=\"padding-right: 30px; padding-left: 30px; margin: 32px 0 40px;\"><table style=\"border-collapse: collapse; border: 0; background-color: #F4F4F4; height: 70px; table-layout: fixed; word-wrap: break-word; border-radius: 6px;\"><tbody><tr><td style=\"text-align: center; vertical-align: middle; font-size: 30px;\">";
+        msg += code;
+        msg += "</td></tr></tbody></table></div>";
+
+        message.setText(msg, "utf-8", "html"); //내용, charset타입, subtype
+        message.setFrom(new InternetAddress(email,"HandsUp_Official")); //보내는 사람의 메일 주소, 보내는 사람 이름
+
+        return message;
+    }
+
+    private String createCode() {
+        StringBuffer code = new StringBuffer();
+        Random random = new Random();
+
+        for (int i = 0; i < 5; i++) { // 인증번호 5자리
+            code.append((random.nextInt(10))); // 0~9
+            }
+        return code.toString();
+    }
+
+    //메일 발송
+    public String sendMail(String email) throws BaseException {
+        String code = createCode();
+        try{
+            MimeMessage mimeMessage = createMessage(code, email);
+            this.javaMailSender.send(mimeMessage);
+            return code;
+        }catch (Exception e){
+            throw new BaseException(BaseResponseStatus.EMAIL_SEND_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/back/handsUp/service/UserService.java
+++ b/src/main/java/com/back/handsUp/service/UserService.java
@@ -28,6 +28,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Transactional;
 import java.security.Principal;
 import java.util.List;
@@ -163,9 +164,9 @@ public class UserService {
         return tokenDto;
     }
 
-    public TokenDto reissue(TokenDto tokenRequestDto) { //재발급
+    public TokenDto reissue(TokenDto tokenRequestDto, HttpServletRequest request) throws BaseException { //재발급
         // 1. Refresh Token 검증
-        if (!this.tokenProvider.validateToken(tokenRequestDto.getRefreshToken())) {
+        if (!this.tokenProvider.validateToken(tokenRequestDto.getRefreshToken(), request)) {
             throw new RuntimeException("Refresh Token 이 유효하지 않습니다.");
         }
 

--- a/src/main/java/com/back/handsUp/service/UserService.java
+++ b/src/main/java/com/back/handsUp/service/UserService.java
@@ -167,7 +167,7 @@ public class UserService {
     public TokenDto reissue(TokenDto tokenRequestDto, HttpServletRequest request) throws BaseException { //재발급
         // 1. Refresh Token 검증
         if (!this.tokenProvider.validateToken(tokenRequestDto.getRefreshToken(), request)) {
-            throw new RuntimeException("Refresh Token 이 유효하지 않습니다.");
+            throw new BaseException(BaseResponseStatus.REFRESH_TOKEN_ERROR);
         }
 
         // 2. Access Token 에서 Member ID 가져오기
@@ -175,11 +175,11 @@ public class UserService {
 
         // 3. 저장소에서 Member ID 를 기반으로 Refresh Token 값 가져옴
         RefreshToken refreshToken = this.refreshTokenRepository.findByKeyId(authentication.getName())
-                .orElseThrow(() -> new RuntimeException("로그아웃 된 사용자입니다."));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.LOGOUT_USER));
 
         // 4. Refresh Token 일치하는지 검사
         if (!refreshToken.getValue().equals(tokenRequestDto.getRefreshToken())) {
-            throw new RuntimeException("토큰의 유저 정보가 일치하지 않습니다.");
+            throw new BaseException(BaseResponseStatus.NOT_MATCH_TOKEN);
         }
 
         // 5. 새로운 토큰 생성

--- a/src/main/java/com/back/handsUp/service/UserService.java
+++ b/src/main/java/com/back/handsUp/service/UserService.java
@@ -82,11 +82,17 @@ public class UserService {
         }
         Character character = optional1.get();
 
-        Optional<School> optional2= this.schoolRepository.findBySchoolIdx(user.getSchoolIdx());
+        Optional<School> optional2= this.schoolRepository.findByName(user.getSchoolName());
+        School school;
+
         if(optional2.isEmpty()){
-            throw new BaseException(BaseResponseStatus.NON_EXIST_SCHOOLIDX);
+            school=School.builder()
+                    .name(user.getSchoolName())
+                    .build();
+            this.schoolRepository.save(school);
+        } else{
+            school = optional2.get();
         }
-        School school = optional2.get();
 
         User userEntity = User.builder()
                 .email(user.getEmail())

--- a/src/main/java/com/back/handsUp/utils/JwtFilter.java
+++ b/src/main/java/com/back/handsUp/utils/JwtFilter.java
@@ -29,7 +29,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // 2. validateToken 으로 토큰 유효성 검사
         // 정상 토큰이면 해당 토큰으로 Authentication 을 가져와서 SecurityContext 에 저장
-        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt, request)) {
             Authentication authentication = tokenProvider.getAuthentication(jwt);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/back/handsUp/utils/TokenProvider.java
+++ b/src/main/java/com/back/handsUp/utils/TokenProvider.java
@@ -88,18 +88,22 @@ public class TokenProvider {
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 
-    public boolean validateToken(String token, ServletRequest request) {
+    public boolean validateToken(String token, ServletRequest request){
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.info("잘못된 JWT 서명입니다.");
+            request.setAttribute("exception", "4043");
         } catch (ExpiredJwtException e) {
             log.info("만료된 JWT 토큰입니다.");
+            request.setAttribute("exception", "4044");
         } catch (UnsupportedJwtException e) {
             log.info("지원되지 않는 JWT 토큰입니다.");
+            request.setAttribute("exception", "4045");
         } catch (IllegalArgumentException e) {
             log.info("JWT 토큰이 잘못되었습니다.");
+            request.setAttribute("exception", "4046");
         }
         return false;
     }

--- a/src/main/java/com/back/handsUp/utils/TokenProvider.java
+++ b/src/main/java/com/back/handsUp/utils/TokenProvider.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import javax.servlet.ServletRequest;
 import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
@@ -45,6 +46,7 @@ public class TokenProvider {
 
         // Access Token 생성
         Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        log.info("accessTokenExpiresIn"+accessTokenExpiresIn);
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())       // payload "sub": "name"
                 .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
@@ -86,7 +88,7 @@ public class TokenProvider {
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 
-    public boolean validateToken(String token) {
+    public boolean validateToken(String token, ServletRequest request) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;

--- a/src/main/java/com/back/handsUp/utils/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/back/handsUp/utils/exception/JwtAuthenticationEntryPoint.java
@@ -13,6 +13,27 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+//        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        String exception =(String)request.getAttribute("exception");
+        if(exception.equals("4043")){
+            setResponse(response, exception, "잘못된 JWT 서명입니다.");
+        } else if (exception.equals("4044")) {
+            setResponse(response, exception, "만료된 JWT 토큰입니다.");
+        } else if (exception.equals("4045")) {
+            setResponse(response, exception, "지원되지 않는 JWT 토큰입니다.");
+        } else if (exception.equals("4046")) {
+            setResponse(response, exception, "JWT 토큰이 잘못되었습니다.");
+        } else {
+            setResponse(response, "4047", "JWT 토큰에 오류가 발생했습니다");
+
+        }
+    }
+
+    private void setResponse(HttpServletResponse response, String errorCode, String message) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().println("{ \"isSuccess\" : " + "false"
+                + ", \"statusCode\" : " +  errorCode
+                + ", \"message\" : \"" + message +"\"}");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,18 @@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/HandsUpDB?characterEncoding=UTF-8&serverTimezone=UTC
-spring.datasource.username=user_handsup
-spring.datasource.password=handsuppw
+spring.datasource.username=root
+spring.datasource.password=0000
 spring.jpa.show-sql=true
 spring.jpa.open-in-view=false
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 jwt.secret=QEWJKKDJLWLCKMSTOIUFXCNMXZSKWEFKWEIOKDFJELKLASDWEHJKLDSFWHKEWFKLDSKLFJDKSAJPQEWKQWOEPIURYTHJKFDBVNBVNKCMSDJEHJIQIORWOQWDKJLSFSALCMVNDFJKDEQOIWURWIEQOKLDJSFDVNDMQPWOEIQURYTGFFDEWERTYUIOPOJHVCXCVBGFRERTYUIKJNBVBNMKOIUYTREWQAZXCVBNMHGFDDFGHJYTREWERTYUIOPOKMDSJKFHKWEJFH
+spring.mail.host=smtp.naver.com
+spring.mail.port=465
+spring.mail.username=handsup_official@naver.com
+spring.mail.password=ENC(9ugKGc6cFCeym4OwRQ+1tor+QQZ/b+By)
+spring.mail.properties.debug=true
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.ssl.enable= true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.ssl.trust=smtp.naver.com


### PR DESCRIPTION
### 📝 작업 내용
- User 도메인의 nicknameUpdatedAt 컬럼에 updatable = false 조건 추가
- 채팅방 조회 API
- 학교 이메일 인증 API
- 이메일 인증 시 사용되는 비밀번호 암호화 설정
- JWT 관련 예외처리 response 설정
### 📢 특이 사항
- 채팅 조회 API → firebase 사용으로 인해 채팅방 조회 API로 변경
- 이후에 JWT secret key 변경 후 암호화 할 것